### PR TITLE
Pull up/down to refresh

### DIFF
--- a/scrollability.js
+++ b/scrollability.js
@@ -69,14 +69,15 @@ window.scrollability = {
         if (scrollables.length) {
             var scrollable = scrollables[0];
             if (scrollable.className.indexOf('vertical') != -1) {
-                scrollability.scrollTo(scrollable, 0, 0, kScrollToTopTime);
+                scrollability.scrollToCeiling(scrollable, kScrollToTopTime);
             }
         }
     },
     
-    scrollToCeiling: function(element) {
+    scrollToCeiling: function(element, animationTime) {
+        animationTime = animationTime || 0;
         var target = createTargetForElement(element);
-        scrollability.scrollTo(element, 0, target.roof, kScrollToTopTime);
+        scrollability.scrollTo(element, 0, target.roof, animationTime);
     },
 
     scrollTo: function(element, x, y, animationTime, muteDelegate) {

--- a/scrollability.js
+++ b/scrollability.js
@@ -1,7 +1,11 @@
 /* See LICENSE for terms of usage */
 (function() {
 
-if (navigator.userAgent.toLowerCase().indexOf("msie")>=0) { return false; }
+if (!navigator.userAgent.match(/iPhone/) && !navigator.userAgent.match(/iPad/) && !navigator.userAgent.match(/iPod/)) {
+    document.documentElement.className += " no-scrollability";
+    return false;
+}
+document.documentElement.className += " scrollability";
 
 // Number of pixels finger must move to determine horizontal or vertical motion
 var kLockThreshold = 10;
@@ -131,14 +135,6 @@ function onScroll(event) {
     });
 }
 
-function addEvent(element, action, callback, bubble) {
-    if (element.attachEvent) {
-        element.attachEvent("on"+action, callback);
-    } else if (element.addEventListener) {
-        element.addEventListener(action, callback, bubble);
-    }
-}
-
 function onOrientationChange(event) {
     justChangedOrientation = true;
 }
@@ -167,9 +163,8 @@ function onTouchStart(event) {
         touched = setTouched(touchCandidate);
     }, 50);
 
-    var d = document;
-    addEvent(d, 'touchmove', onTouchMove, false);
-    addEvent(d, 'touchend', onTouchEnd, false);
+    document.addEventListener('touchmove', onTouchMove, false);
+    document.addEventListener('touchend', onTouchEnd, false);
 
     animationInterval = setInterval(touchAnimation, 0);
 
@@ -224,8 +219,8 @@ function onTouchStart(event) {
             } catch(e) {}
         }
 
-        d.removeEventListener('touchmove', onTouchMove, false);
-        d.removeEventListener('touchend', onTouchEnd, false);
+        document.removeEventListener('touchmove', onTouchMove, false);
+        document.removeEventListener('touchend', onTouchEnd, false);
         touchDown = false;
     }
 }
@@ -751,9 +746,9 @@ function createYTarget(element) {
     };
 }
 
-addEvent(document, 'touchstart', onTouchStart, false);
-addEvent(document, 'scroll', onScroll, false);
-addEvent(document, 'orientationchange', onOrientationChange, false);
-addEvent(window, 'load', onLoad, false);
+document.addEventListener('touchstart', onTouchStart, false);
+document.addEventListener('scroll', onScroll, false);
+document.addEventListener('orientationchange', onOrientationChange, false);
+window.addEventListener('load', onLoad, false);
 
 })();

--- a/scrollability.js
+++ b/scrollability.js
@@ -1,6 +1,8 @@
 /* See LICENSE for terms of usage */
 (function() {
 
+if (navigator.userAgent.toLowerCase().indexOf("msie")>=0) { return false; }
+
 // Number of pixels finger must move to determine horizontal or vertical motion
 var kLockThreshold = 10;
 
@@ -122,6 +124,14 @@ function onScroll(event) {
     });
 }
 
+function addEvent(element, action, callback, bubble) {
+	if (element.attachEvent) {
+		element.attachEvent("on"+action, callback);
+	} else if (element.addEventListener) {
+		element.addEventListener(action, callback, bubble);
+	}
+}
+
 function onOrientationChange(event) {
     justChangedOrientation = true;
 }
@@ -151,8 +161,8 @@ function onTouchStart(event) {
     }, 50);
 
     var d = document;
-    d.addEventListener('touchmove', onTouchMove, false);
-    d.addEventListener('touchend', onTouchEnd, false);
+    addEvent(d, 'touchmove', onTouchMove, false);
+    addEvent(d, 'touchend', onTouchEnd, false);
 
     animationInterval = setInterval(touchAnimation, 0);
 
@@ -727,9 +737,9 @@ function createYTarget(element) {
     };
 }
 
-document.addEventListener('touchstart', onTouchStart, false);
-document.addEventListener('scroll', onScroll, false);
-document.addEventListener('orientationchange', onOrientationChange, false);
-window.addEventListener('load', onLoad, false);
+addEvent(document, 'touchstart', onTouchStart, false);
+addEvent(document, 'scroll', onScroll, false);
+addEvent(document, 'orientationchange', onOrientationChange, false);
+addEvent(window, 'load', onLoad, false);
 
 })();

--- a/scrollability.js
+++ b/scrollability.js
@@ -53,13 +53,14 @@ var scrollers = {
 
 window.scrollability = {
     globalScrolling: false,
-    scrollers: scrollers,
     useOnScrollEvt: false,
+    scrollers: scrollers,
 
     flashIndicators: function() {
-        var scrollables = document.querySelectorAll('.scrollable.vertical');
-        for (var i = 0; i < scrollables.length; ++i) {
-            scrollability.scrollTo(scrollables[i], 0, 0, 20, true);
+        var i, scrollables = document.querySelectorAll('.scrollable.vertical');
+        for (i = 0; i < scrollables.length; ++i) {
+            var scrollable = scrollables[i];
+            scrollability.scrollToCeiling(scrollable);
         }
     },
     
@@ -71,6 +72,11 @@ window.scrollability = {
                 scrollability.scrollTo(scrollable, 0, 0, kScrollToTopTime);
             }
         }
+    },
+    
+    scrollToCeiling: function(element) {
+        var target = createTargetForElement(element);
+        scrollability.scrollTo(element, 0, target.roof, kScrollToTopTime);
     },
 
     scrollTo: function(element, x, y, animationTime, muteDelegate) {
@@ -125,11 +131,11 @@ function onScroll(event) {
 }
 
 function addEvent(element, action, callback, bubble) {
-	if (element.attachEvent) {
-		element.attachEvent("on"+action, callback);
-	} else if (element.addEventListener) {
-		element.addEventListener(action, callback, bubble);
-	}
+    if (element.attachEvent) {
+        element.attachEvent("on"+action, callback);
+    } else if (element.addEventListener) {
+        element.addEventListener(action, callback, bubble);
+    }
 }
 
 function onOrientationChange(event) {
@@ -704,18 +710,25 @@ function createXTarget(element) {
 
 function createYTarget(element) {
     var parent = element.parentNode,
-        pullDownToRefresh = parent.getElementsByClassName('pull-down-to-refresh')[0];
-        pullUpToRefresh = parent.getElementsByClassName('pull-up-to-refresh')[0];
+        pullUpToRefresh = parent.getElementsByClassName('pull-up-to-refresh')[0],
+        pullDownToRefresh = parent.getElementsByClassName('pull-down-to-refresh')[0],
+        hiddenAbove = parent.getElementsByClassName('hidden-above')[0];
+    
+    var min = -parent.scrollHeight + parent.offsetHeight + (pullUpToRefresh ? pullUpToRefresh.offsetHeight : 0);
+    var max = (pullDownToRefresh ? -pullDownToRefresh.offsetHeight : 0);
+    var roof = max + (hiddenAbove ? -hiddenAbove.offsetHeight : 0);
+    
     return {
         node: element,
         scrollbar: initScrollbar(element),
-        min: -parent.scrollHeight + parent.offsetHeight
-             + (pullUpToRefresh ? pullUpToRefresh.offsetHeight : 0),
-        max: (pullDownToRefresh ? -pullDownToRefresh.offsetHeight : 0),
+        min: min,
+        max: max,
+        roof: roof,
         viewport: parent.offsetHeight,
         bounce: parent.offsetHeight * kBounceLimit,
         pullUpToRefresh: pullUpToRefresh ? pullUpToRefresh : false,
         pullDownToRefresh: pullDownToRefresh ? pullDownToRefresh : false,
+        hiddenAbove: hiddenAbove ? hiddenAbove : false,
         constrained: true,
         delegate: element.scrollDelegate,
 

--- a/scrollability.js
+++ b/scrollability.js
@@ -458,12 +458,12 @@ function wrapTarget(target, startX, startY, startTime) {
     }
 
     function pullToRefresh(released) {
-        var pullUpMin = min - target.pullUpToRefresh.offsetHeight / 2;
-        var pullDownMin = max + target.pullDownToRefresh.offsetHeight;
         var pullState;
         
         return function() {
             if (target.pullUpToRefresh || target.pullDownToRefresh) {
+                var pullUpMin = min - target.pullUpToRefresh.offsetHeight / 2;
+                var pullDownMin = max + target.pullDownToRefresh.offsetHeight / 2;
                 if ( !released && 
                         (
                             (isPullingDown && ((pullDownMin < position && pullState) || (pullDownMin > position && !pullState)))


### PR DESCRIPTION
Building off of endtwist's changes [1], I've added pull down to refresh.

An element with the class "pull-down-to-refresh" will be hidden above the "top" of the list and will fire `pullingDown`, `pulledDown` and `pullDownCancel` back to the list.

An elements with the class "pull-up-to-refresh" will be hidden below the "bottom" of the list and will fire `pullingUp`, `pulledUp` and `pullUpCancel` back to the list.

In regard to endtwist's `scroll` event, I've added a boolean called `useOnScrollEvt` which defaults to false so that the event is not fired if it's not needed.

[1] https://github.com/joehewitt/scrollability/pull/17
